### PR TITLE
V2 POST endpoint to create multi line addresses for correspondence address

### DIFF
--- a/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/ContactInformationValidatorTests.cs
+++ b/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/ContactInformationValidatorTests.cs
@@ -107,14 +107,6 @@ namespace ContactDetailsApi.Tests.V2.Boundary.Request.Validation
             result.ShouldHaveValidationErrorFor(x => x.Value);
         }
 
-
-
-
-
-
-
-
-
         [Fact]
         public void ValueShouldErrorWithTagsInValue()
         {

--- a/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/ContactInformationValidatorTests.cs
+++ b/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/ContactInformationValidatorTests.cs
@@ -1,0 +1,273 @@
+using ContactDetailsApi.V1.Boundary.Request.Validation;
+using ContactDetailsApi.V1.Domain;
+using ContactDetailsApi.V2.Boundary.Request.Validation;
+using ContactDetailsApi.V2.Domain;
+using FluentValidation.TestHelper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using AddressExtended = ContactDetailsApi.V2.Domain.AddressExtended;
+using ContactInformation = ContactDetailsApi.V2.Domain.ContactInformation;
+using ContactInformationValidator = ContactDetailsApi.V2.Boundary.Request.Validation.ContactInformationValidator;
+
+namespace ContactDetailsApi.Tests.V2.Boundary.Request.Validation
+{
+    public class ContactInformationValidatorTests
+    {
+        private readonly ContactInformationValidator _sut;
+        private const string StringWithTags = "Some string with <tag> in it.";
+
+        public ContactInformationValidatorTests()
+        {
+            _sut = new ContactInformationValidator();
+        }
+
+        private static IEnumerable<object[]> GetEnumValues<T>() where T : Enum
+        {
+            foreach (var val in Enum.GetValues(typeof(T)))
+            {
+                yield return new object[] { val };
+            }
+        }
+
+        public static IEnumerable<object[]> ContactTypes => GetEnumValues<ContactType>();
+        public static IEnumerable<object[]> SubTypes => GetEnumValues<SubType>();
+
+        [Theory]
+        [MemberData(nameof(ContactTypes))]
+        public void ContactTypeShouldNotErrorWithValidValue(ContactType valid)
+        {
+            // Arrange
+            var model = new ContactInformation() { ContactType = valid };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.ContactType);
+        }
+
+        [Theory]
+        [InlineData(100)]
+        public void ContactTypeShouldErrorWithInvalidValue(int? val)
+        {
+            // Arrange
+            var model = new ContactInformation() { ContactType = (ContactType) val };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.ContactType);
+        }
+
+        [Theory]
+        [MemberData(nameof(SubTypes))]
+        [InlineData(null)]
+        public void SubTypeShouldNotErrorWithValidValue(SubType? valid)
+        {
+            // Arrange
+            var model = new ContactInformation() { SubType = valid };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.SubType);
+        }
+
+        [Theory]
+        [InlineData(100)]
+        public void SubTypeShouldErrorWithInvalidValue(int? val)
+        {
+            // Arrange
+            var model = new ContactInformation() { SubType = (SubType) val };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SubType);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void ValueShouldErrorWithNoValue(string invalid)
+        {
+            // Arrange
+            var model = new ContactInformation() { Value = invalid };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Value);
+        }
+
+
+
+
+
+
+
+
+
+        [Fact]
+        public void ValueShouldErrorWithTagsInValue()
+        {
+            // Arrange
+            var model = new ContactInformation() { Value = StringWithTags };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Value)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+        [Theory]
+        [InlineData("invalidEmail")]
+        [InlineData("@invalidEmail")]
+        [InlineData("invalidEmail@")]
+        public void ValueShouldErrorWithInvalidEmail(string invalid)
+        {
+            // Arrange
+            var model = new ContactInformation()
+            {
+                Value = invalid,
+                ContactType = ContactType.email
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Value)
+                  .WithErrorCode(ErrorCodes.InvalidEmail);
+        }
+
+        [Fact]
+        public void ValueShouldNotErrorWithValidEmail()
+        {
+            // Arrange
+            var model = new ContactInformation()
+            {
+                Value = "a.b@c.com",
+                ContactType = ContactType.email
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Value);
+        }
+
+        [Theory]
+        [InlineData("invalidphone")]
+        [InlineData("3214")]
+        public void ValueShouldErrorWithInvalidPhoneNumber(string invalid)
+        {
+            // Arrange
+            var model = new ContactInformation()
+            {
+                Value = invalid,
+                ContactType = ContactType.phone
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Value)
+                  .WithErrorCode(ErrorCodes.InvalidPhoneNumber);
+        }
+
+        [Theory]
+        [InlineData("01234 654987")]
+        [InlineData("(01234) 654987")]
+        [InlineData("+44 1234 654987")]
+        public void ValueShouldNotErrorWithValidPhoneNumber(string valid)
+        {
+            // Arrange
+            var model = new ContactInformation()
+            {
+                Value = valid,
+                ContactType = ContactType.phone
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Value);
+        }
+
+        [Fact]
+        public void ValueShouldNotErrorWithWhenContactTypeIsAddress()
+        {
+            // Arrange
+            var model = new ContactInformation()
+            {
+                Value = null,
+                ContactType = ContactType.address
+            };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Value);
+        }
+
+        [Fact]
+        public void DescriptionShouldErrorWithWithTagsInValue()
+        {
+            // Arrange
+            var model = new ContactInformation() { Description = StringWithTags };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Description)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Mr Joe Bloggs")]
+        public void DescriptionShouldNotErrorValidValue(string valid)
+        {
+            // Arrange
+            var model = new ContactInformation() { Description = valid };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldNotHaveValidationErrorFor(x => x.Description);
+        }
+
+        [Fact]
+        public void AddressExtendedShouldErrorWithInvalidValue()
+        {
+            // Arrange
+            var invalidAddressExtended = new AddressExtended() { UPRN = StringWithTags };
+            var model = new ContactInformation() { AddressExtended = invalidAddressExtended };
+
+            // Act
+            var result = _sut.TestValidate(model);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.AddressExtended.UPRN)
+                  .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+    }
+}

--- a/ContactDetailsApi/V2/Boundary/Request/Validation/ContactInformationValidator.cs
+++ b/ContactDetailsApi/V2/Boundary/Request/Validation/ContactInformationValidator.cs
@@ -14,7 +14,8 @@ namespace ContactDetailsApi.V2.Boundary.Request.Validation
 
             RuleFor(x => x.SubType).IsInEnum().When(x => x.SubType.HasValue);
 
-            RuleFor(x => x.Value).NotNull().NotEmpty();
+            // value field not required for type address
+            RuleFor(x => x.Value).NotNull().NotEmpty().When(x => x.ContactType != ContactType.address);
 
             RuleFor(x => x.Value).NotXssString()
                 .WithErrorCode(ErrorCodes.XssCheckFailure)


### PR DESCRIPTION
Updates validation rules.

## Link to JIRA ticket

[Jira Ticket](https://hackney.atlassian.net/jira/software/projects/MTTL/boards/47?selectedIssue=MTTL-1591)

## Describe this PR

When testing, I noticed that the value field was still required in the post request. I have changed the validation rules to resolve this.

The the tests are the same as v1, except for one:
- ValueShouldNotErrorWithWhenContactTypeIsAddress

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
