### PR TITLE
Remove PostCode validation.

### DIFF
--- a/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/AddressExtendedValidatorTests.cs
+++ b/ContactDetailsApi.Tests/V2/Boundary/Request/Validation/AddressExtendedValidatorTests.cs
@@ -177,10 +177,7 @@ namespace ContactDetailsApi.Tests.V2.Boundary.Request.Validation
 
         [Theory]
         [InlineData("")]
-        [InlineData(" ")]
         [InlineData(null)]
-        [InlineData("hd7   5uz")]
-        [InlineData("adasd")]
         public void ShouldErrorPostCodeWhenAddressTypeIsAddress(string postCode)
         {
             // Arrange

--- a/ContactDetailsApi.Tests/V2/E2ETests/Fixtures/ContactDetailsFixture.cs
+++ b/ContactDetailsApi.Tests/V2/E2ETests/Fixtures/ContactDetailsFixture.cs
@@ -144,7 +144,7 @@ namespace ContactDetailsApi.Tests.V2.E2ETests.Fixtures
             ContactRequestObject = CreateContactRestObject();
 
             var addressExtended = _fixture.Build<AddressExtended>()
-               .With(x => x.PostCode, "")
+               .With(x => x.PostCode, (string) null)
                .Create();
 
             ContactRequestObject.ContactInformation.AddressExtended = addressExtended;

--- a/ContactDetailsApi/V2/Boundary/Request/Validation/AddressExtendedValidator.cs
+++ b/ContactDetailsApi/V2/Boundary/Request/Validation/AddressExtendedValidator.cs
@@ -8,8 +8,6 @@ namespace ContactDetailsApi.V2.Boundary.Request.Validation
 {
     public class AddressExtendedValidator : AbstractValidator<AddressExtended>
     {
-        private const string PostCodeRegEx = @"^((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]))))( )?(([0-9][A-Za-z]?[A-Za-z]?)?))$";
-
         public AddressExtendedValidator(ContactType contactType)
         {
             RuleFor(x => x.UPRN).NotXssString()
@@ -55,9 +53,6 @@ namespace ContactDetailsApi.V2.Boundary.Request.Validation
                 RuleFor(x => x.PostCode)
                     .NotNull()
                     .NotEmpty();
-
-                RuleFor(x => x.PostCode).Matches(PostCodeRegEx)
-                    .WithErrorCode(ErrorCodes.InvalidEmail);
             });
         }
     }


### PR DESCRIPTION
The PostCode in AddressExtended was supposed to be free text.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly