### PR TITLE
MR-760 - Commented out module "sns-delivery-failure-alarm" in prod main.tf file as not working

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -79,12 +79,13 @@ module "api-alarm" {
   error_threshold  = "1"
   sns_topic_arn    = data.aws_ssm_parameter.cloudwatch_topic_arn.value
 }
-    
-module "sns-delivery-failure-alarm" {
-  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/sns-delivery-metric-and-alarm"
-  environment_name = var.environment_name
-  region           = data.aws_region.current.name
-  account_id       = data.aws_caller_identity.current.account_id
-  sns_topic_name   = "contactdetails.fifo"
-  sns_topic_arn_for_notifications = data.aws_ssm_parameter.cloudwatch_topic_arn.value
-}
+
+# NOT WORKING NEEDS TO BE INVESTIGATED
+# module "sns-delivery-failure-alarm" {
+#   source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/sns-delivery-metric-and-alarm"
+#   environment_name = var.environment_name
+#   region           = data.aws_region.current.name
+#   account_id       = data.aws_caller_identity.current.account_id
+#   sns_topic_name   = "contactdetails.fifo"
+#   sns_topic_arn_for_notifications = data.aws_ssm_parameter.cloudwatch_topic_arn.value
+# }


### PR DESCRIPTION
Deployment of contact-details-api to production is blocked by this error:

![image](https://github.com/LBHackney-IT/contact-details-api/assets/70756861/330edb51-ee90-490d-80b4-bde04f21d868)

This error includes an unusual log group name, which does not exist in our AWS infrastructure.

The production `main.tf` file, when it comes to the` module "sns-delivery-failure-alarm"` has a dependency on another Hackney repository that "does not seem to work". In this case specifically, the error seems to be caused by line 3 in [this file](https://github.com/LBHackney-IT/aws-hackney-common-terraform/blob/master/modules/cloudwatch/sns-delivery-metric-and-alarm/main.tf), which resolves into an incorrect log group name.

The same exact module has been commented out in [Person API](https://github.com/LBHackney-IT/person-api/commit/1390f61d4225b7178afa00b9908f68abf0f14b1e) and [Tenure API](https://github.com/LBHackney-IT/tenure-api/commit/3de857f25bac3bfc0413493fabf4fef10daf5bdb).

Commenting this out should allow us to deploy contact-details-api to production for now. I will however add a new issue in our Tech Debt sheet so that this issue can be addressed.