### PR TITLE
Safe data conversion for Servicesoft

### DIFF
--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -64,7 +64,15 @@ namespace ContactDetailsApi.V2.Gateways
                 };
             };
 
-            return contactDetailsEntities?.Select(cdEntity => SafeToDomain(cdEntity)).Where(cdEnity => cdEnity != null).ToList();
+            return contactDetailsEntities?.Select(cdEntity => SafeToDomain(cdEntity))
+                .Where(cdEnity => cdEnity != null)
+                .OrderBy(x => x?.CreatedBy?.CreatedAt)
+                .ToList();
+        }
+
+        private void ConvertToDomain(List<ContactDetailsEntity> contactDetailsEntities)
+        {
+            throw new NotImplementedException();
         }
 
         [LogCall]

--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -51,10 +51,14 @@ namespace ContactDetailsApi.V2.Gateways
                 contactDetailsEntities.AddRange(newResults);
             } while (!search.IsDone);
 
-            ContactDetails SafeToDomain(ContactDetailsEntity cdEntity) {
-                try {
+            ContactDetails SafeToDomain(ContactDetailsEntity cdEntity)
+            {
+                try
+                {
                     return cdEntity?.ToDomain();
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     _logger.LogError(e, "Error: Failed to convert contact details {CdEntity} to ContactDetails domain", cdEntity?.Id);
                     return null;
                 };

--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -51,7 +51,16 @@ namespace ContactDetailsApi.V2.Gateways
                 contactDetailsEntities.AddRange(newResults);
             } while (!search.IsDone);
 
-            return contactDetailsEntities?.ToDomain();
+            ContactDetails SafeToDomain(ContactDetailsEntity cdEntity) {
+                try {
+                    return cdEntity?.ToDomain();
+                } catch (Exception e) {
+                    _logger.LogError(e, "Error: Failed to convert contact details {CdEntity} to ContactDetails domain", cdEntity?.Id);
+                    return null;
+                };
+            };
+
+            return contactDetailsEntities?.Select(cdEntity => SafeToDomain(cdEntity)).Where(cdEnity => cdEnity != null).ToList();
         }
 
         [LogCall]

--- a/ContactDetailsApi/V2/Gateways/PersonDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/PersonDbGateway.cs
@@ -33,8 +33,17 @@ namespace ContactDetailsApi.V2.Gateways
                 batchGet.AddKey(id);
             }
 
+            Person SafeToDomain(PersonDbEntity person) {
+                try {
+                    return person?.ToDomain();
+                } catch (Exception e) {
+                    _logger.LogError(e, "Error: Failed to convert person {PersonDb} to Person domain", person?.Id);
+                    return null;
+                };
+            };
+
             await batchGet.ExecuteAsync().ConfigureAwait(false);
-            return batchGet.Results.Select(x => x.ToDomain());
+            return batchGet.Results.Select(person => SafeToDomain(person)).Where(person => person != null);
         }
     }
 }

--- a/ContactDetailsApi/V2/Gateways/PersonDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/PersonDbGateway.cs
@@ -33,10 +33,14 @@ namespace ContactDetailsApi.V2.Gateways
                 batchGet.AddKey(id);
             }
 
-            Person SafeToDomain(PersonDbEntity person) {
-                try {
+            Person SafeToDomain(PersonDbEntity person)
+            {
+                try
+                {
                     return person?.ToDomain();
-                } catch (Exception e) {
+                }
+                catch (Exception e)
+                {
                     _logger.LogError(e, "Error: Failed to convert person {PersonDb} to Person domain", person?.Id);
                     return null;
                 };

--- a/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
@@ -44,8 +44,18 @@ public class TenureDbGateway : ITenureDbGateway
 
         // _logger.LogInformation("Returned {resultsCount} results from IDynamoDBContext.ScanAsync for TenureInformationDb with pagination token {paginationToken}", resultsSet.Count, paginationToken);
 
+        TenureInformation SafeToDomain(TenureInformationDb tenure) {
+            try {
+                return tenure?.ToDomain();
+            } catch (Exception e) {
+                _logger.LogError(e, "Error: Failed to convert tenure {Tenure} to TenureInformation domain", tenure?.Id);
+                return null;
+            };
+        };
+
         return new PagedResult<TenureInformation>(
-            resultsSet.Select(x => x.ToDomain()),
+            resultsSet.Select(tenure => SafeToDomain(tenure))
+            .Where(tenure => tenure != null),
             new PaginationDetails(paginationToken)
         );
     }

--- a/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
@@ -44,10 +44,14 @@ public class TenureDbGateway : ITenureDbGateway
 
         // _logger.LogInformation("Returned {resultsCount} results from IDynamoDBContext.ScanAsync for TenureInformationDb with pagination token {paginationToken}", resultsSet.Count, paginationToken);
 
-        TenureInformation SafeToDomain(TenureInformationDb tenure) {
-            try {
+        TenureInformation SafeToDomain(TenureInformationDb tenure)
+        {
+            try
+            {
                 return tenure?.ToDomain();
-            } catch (Exception e) {
+            }
+            catch (Exception e)
+            {
                 _logger.LogError(e, "Error: Failed to convert tenure {Tenure} to TenureInformation domain", tenure?.Id);
                 return null;
             };


### PR DESCRIPTION
We need to provide ServiceSoft with the ability to fetch a complete list of tenures and contact details for a household member in the tenures, however if any database record in the table has data misaligned with our domain objects, this will cause the entire table scan to fail.

To make the API more resilient against this, we are adding safe data conversion methods that will skip over records that fail to convert into our domain objects, and log errors for these instead - we can then investigate and fix these records on demand while still providing Servicesoft with working data.