### PR TITLE
changed servicesoft endpoint to filter by proref

### DIFF
--- a/ContactDetailsApi.Tests/V2/Controller/ServiceSoftControllerTests.cs
+++ b/ContactDetailsApi.Tests/V2/Controller/ServiceSoftControllerTests.cs
@@ -33,7 +33,7 @@ namespace ContactDetailsApi.Tests.V2.Controller
         public async Task FetchAllContactDetailsReturns200Response()
         {
             // Arrange
-            var response = _fixture.Create<PagedResult<ContactByUprn>>();
+            var response = _fixture.Create<PagedResult<ContactByPropRef>>();
             var request = _fixture.Create<ServicesoftFetchContactDetailsRequest>();
 
             _mockFetchAllContactDetailsByUprn.Setup(x => x.ExecuteAsync(request)).ReturnsAsync(response);

--- a/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByUprnStep.cs
+++ b/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByUprnStep.cs
@@ -67,13 +67,13 @@ namespace ContactDetailsApi.Tests.V2.E2ETests.Steps
             results.Should().SatisfyRespectively(x => x.Contacts.TrueForAll(x => x.IsResponsible));
 
             results.Should().OnlyContain(x => x.TenureId != null);
-            foreach (var ContactByPropRef in results)
+            foreach (var contactByPropRef in results)
             {
-                var tenure = await dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(ContactByPropRef.TenureId.Value);
+                var tenure = await dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(contactByPropRef.TenureId.Value);
                 tenure.ToDomain().IsActive.Should().BeTrue();
-                ContactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
-                ContactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset.PropertyReference);
-                ContactByPropRef.Contacts.Select(x => x.Id).Should().IntersectWith(tenure.HouseholdMembers.Select(x => x.Id));
+                contactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
+                contactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset.PropertyReference);
+                contactByPropRef.Contacts.Select(x => x.Id).Should().IntersectWith(tenure.HouseholdMembers.Select(x => x.Id));
             }
 
             var paginationDetails = apiResult.PaginationDetails;

--- a/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByUprnStep.cs
+++ b/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByUprnStep.cs
@@ -46,34 +46,34 @@ namespace ContactDetailsApi.Tests.V2.E2ETests.Steps
             _lastResponse = await CallApi().ConfigureAwait(false);
         }
 
-        private async Task<PagedResult<ContactByUprn>> ExtractResultFromHttpResponse(HttpResponseMessage response)
+        private async Task<PagedResult<ContactByPropRef>> ExtractResultFromHttpResponse(HttpResponseMessage response)
         {
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var apiResult = JsonSerializer.Deserialize<PagedResult<ContactByUprn>>(responseContent, _jsonOptions);
+            var apiResult = JsonSerializer.Deserialize<PagedResult<ContactByPropRef>>(responseContent, _jsonOptions);
             return apiResult;
         }
 
         public async Task ThenAllContactDetailsAreReturned(IDynamoDbFixture dbFixture)
         {
             var apiResult = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
-            apiResult.Should().BeOfType<PagedResult<ContactByUprn>>();
+            apiResult.Should().BeOfType<PagedResult<ContactByPropRef>>();
 
             var results = apiResult.Results;
             results.Should().NotBeNullOrEmpty();
-            results.Should().BeOfType<List<ContactByUprn>>();
+            results.Should().BeOfType<List<ContactByPropRef>>();
 
             results.Should().SatisfyRespectively(x => x.Contacts.Should().NotBeNullOrEmpty());
             results.Should().SatisfyRespectively(x => x.Contacts.TrueForAll(x => x.IsResponsible));
 
             results.Should().OnlyContain(x => x.TenureId != null);
-            foreach (var contactByUprn in results)
+            foreach (var ContactByPropRef in results)
             {
-                var tenure = await dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(contactByUprn.TenureId.Value);
+                var tenure = await dbFixture.DynamoDbContext.LoadAsync<TenureInformationDb>(ContactByPropRef.TenureId.Value);
                 tenure.ToDomain().IsActive.Should().BeTrue();
-                contactByUprn.Address.Should().Be(tenure.TenuredAsset.FullAddress);
-                contactByUprn.Uprn.Should().Be(tenure.TenuredAsset.Uprn);
-                contactByUprn.Contacts.Select(x => x.Id).Should().IntersectWith(tenure.HouseholdMembers.Select(x => x.Id));
+                ContactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
+                ContactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset.PropertyReference);
+                ContactByPropRef.Contacts.Select(x => x.Id).Should().IntersectWith(tenure.HouseholdMembers.Select(x => x.Id));
             }
 
             var paginationDetails = apiResult.PaginationDetails;

--- a/ContactDetailsApi.Tests/V2/Factories/EntityFactoryTests.cs
+++ b/ContactDetailsApi.Tests/V2/Factories/EntityFactoryTests.cs
@@ -397,7 +397,7 @@ namespace ContactDetailsApi.Tests.V2.Factories
             var databaseEntities = _fixture.CreateMany<ContactDetails>(10);
 
             // Act
-            var personContactDetailsList = databaseEntities.ToContactByUprnPersonContacts();
+            var personContactDetailsList = databaseEntities.ToContactByPropRefPersonContacts();
 
             // Assert
             personContactDetailsList.Should().BeEquivalentTo(databaseEntities, options => options.ExcludingMissingMembers());
@@ -412,7 +412,7 @@ namespace ContactDetailsApi.Tests.V2.Factories
             var contactDetails = _fixture.Create<List<PersonContactDetails>>();
 
             // Act
-            var person = personDetails.ToContactByUprnPerson(householdMember, contactDetails);
+            var person = personDetails.ToContactByPropRefPerson(householdMember, contactDetails);
 
             // Assert
             person.Id.Should().Be(householdMember.Id);
@@ -425,20 +425,20 @@ namespace ContactDetailsApi.Tests.V2.Factories
         }
 
         [Fact]
-        public void CanMapTenureAndPersonToContactByUprn()
+        public void CanMapTenureAndPersonToContactByPropRef()
         {
             // Arrange
             var tenure = _fixture.Create<TenureInformation>();
             var contacts = _fixture.Create<List<Person>>();
 
             // Act
-            var contactByUprn = tenure.ToContactByUprn(contacts);
+            var ContactByPropRef = tenure.ToContactByPropRef(contacts);
 
             // Assert
-            contactByUprn.TenureId.Should().Be(tenure.Id);
-            contactByUprn.Address.Should().Be(tenure.TenuredAsset.FullAddress);
-            contactByUprn.Uprn.Should().Be(tenure.TenuredAsset?.Uprn);
-            contactByUprn.Contacts.Should().BeEquivalentTo(contacts);
+            ContactByPropRef.TenureId.Should().Be(tenure.Id);
+            ContactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
+            ContactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset?.PropertyReference);
+            ContactByPropRef.Contacts.Should().BeEquivalentTo(contacts);
         }
     }
 }

--- a/ContactDetailsApi.Tests/V2/Factories/EntityFactoryTests.cs
+++ b/ContactDetailsApi.Tests/V2/Factories/EntityFactoryTests.cs
@@ -432,13 +432,13 @@ namespace ContactDetailsApi.Tests.V2.Factories
             var contacts = _fixture.Create<List<Person>>();
 
             // Act
-            var ContactByPropRef = tenure.ToContactByPropRef(contacts);
+            var contactByPropRef = tenure.ToContactByPropRef(contacts);
 
             // Assert
-            ContactByPropRef.TenureId.Should().Be(tenure.Id);
-            ContactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
-            ContactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset?.PropertyReference);
-            ContactByPropRef.Contacts.Should().BeEquivalentTo(contacts);
+            contactByPropRef.TenureId.Should().Be(tenure.Id);
+            contactByPropRef.Address.Should().Be(tenure.TenuredAsset.FullAddress);
+            contactByPropRef.PropertyRef.Should().Be(tenure.TenuredAsset?.PropertyReference);
+            contactByPropRef.Contacts.Should().BeEquivalentTo(contacts);
         }
     }
 }

--- a/ContactDetailsApi.Tests/V2/UseCase/FetchAllContactDetailsUseCaseTests.cs
+++ b/ContactDetailsApi.Tests/V2/UseCase/FetchAllContactDetailsUseCaseTests.cs
@@ -61,11 +61,11 @@ namespace ContactDetailsApi.Tests.V2.UseCase
 
             // Assert
             result.Should().NotBeNullOrEmpty();
-            result.Should().BeOfType<List<ContactByUprn>>();
+            result.Should().BeOfType<List<ContactByPropRef>>();
             result.Should().HaveCount(1);
 
             var resultItem = result.First();
-            resultItem.Uprn.Should().Be(tenure.TenuredAsset.Uprn);
+            resultItem.PropertyRef.Should().Be(tenure.TenuredAsset.PropertyReference);
             resultItem.TenureId.Should().Be(tenure.Id);
             resultItem.Contacts.Should().NotBeNullOrEmpty();
             resultItem.Contacts.Should().HaveCount(1);
@@ -102,11 +102,11 @@ namespace ContactDetailsApi.Tests.V2.UseCase
 
             // Assert
             result.Should().NotBeNullOrEmpty();
-            result.Should().BeOfType<List<ContactByUprn>>();
+            result.Should().BeOfType<List<ContactByPropRef>>();
             result.Should().HaveCount(1);
 
             var resultItem = result.First();
-            resultItem.Uprn.Should().Be(tenure.TenuredAsset.Uprn);
+            resultItem.PropertyRef.Should().Be(tenure.TenuredAsset.PropertyReference);
             resultItem.TenureId.Should().Be(tenure.Id);
             resultItem.Contacts.Should().NotBeNullOrEmpty();
             resultItem.Contacts.Should().HaveCount(1);
@@ -148,7 +148,7 @@ namespace ContactDetailsApi.Tests.V2.UseCase
 
             // Assert
             result.Should().NotBeNullOrEmpty();
-            result.Should().BeOfType<List<ContactByUprn>>();
+            result.Should().BeOfType<List<ContactByPropRef>>();
             result.Should().HaveCount(1); // Only 1 tenure
             result.First().TenureId.Should().Be(tenures.First().Id);
             result.First().Address.Should().Be(tenures.First().TenuredAsset.FullAddress);

--- a/ContactDetailsApi/ContactDetailsApi.csproj
+++ b/ContactDetailsApi/ContactDetailsApi.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
     <PackageReference Include="Hackney.Shared.Person" Version="0.14.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />

--- a/ContactDetailsApi/V2/Domain/ContactPropRefs.cs
+++ b/ContactDetailsApi/V2/Domain/ContactPropRefs.cs
@@ -6,9 +6,9 @@ using Hackney.Shared.Person.Domain;
 
 namespace ContactDetailsApi.V2.Domain
 {
-    public class ContactByUprn
+    public class ContactByPropRef
     {
-        public string Uprn { get; set; }
+        public string PropertyRef { get; set; }
         public string Address { get; set; }
         public Guid? TenureId { get; set; }
         public List<Person> Contacts { get; set; }

--- a/ContactDetailsApi/V2/Factories/EntityFactory.cs
+++ b/ContactDetailsApi/V2/Factories/EntityFactory.cs
@@ -123,7 +123,7 @@ namespace ContactDetailsApi.V2.Factories
             };
         }
 
-        public static List<PersonContactDetails> ToContactByUprnPersonContacts(this IEnumerable<ContactDetails> databaseEntity)
+        public static List<PersonContactDetails> ToContactByPropRefPersonContacts(this IEnumerable<ContactDetails> databaseEntity)
         {
             if (databaseEntity == null || !databaseEntity.Any()) return null;
             return databaseEntity
@@ -131,7 +131,7 @@ namespace ContactDetailsApi.V2.Factories
                 .ToList();
         }
 
-        public static Person ToContactByUprnPerson(this Hackney.Shared.Person.Person personDetails, HouseholdMembers householdMember,
+        public static Person ToContactByPropRefPerson(this Hackney.Shared.Person.Person personDetails, HouseholdMembers householdMember,
             List<PersonContactDetails> contactDetails)
         {
             return new Person
@@ -146,13 +146,13 @@ namespace ContactDetailsApi.V2.Factories
             };
         }
 
-        public static ContactByUprn ToContactByUprn(this TenureInformation tenure, List<Person> contacts)
+        public static ContactByPropRef ToContactByPropRef(this TenureInformation tenure, List<Person> contacts)
         {
-            return new ContactByUprn
+            return new ContactByPropRef
             {
                 TenureId = tenure.Id,
                 Address = tenure.TenuredAsset?.FullAddress,
-                Uprn = tenure.TenuredAsset?.Uprn,
+                PropertyRef = tenure.TenuredAsset?.PropertyReference,
                 Contacts = contacts
             };
         }

--- a/ContactDetailsApi/V2/UseCase/Interfaces/IFetchAllContactDetailsByUprnUseCase.cs
+++ b/ContactDetailsApi/V2/UseCase/Interfaces/IFetchAllContactDetailsByUprnUseCase.cs
@@ -8,6 +8,6 @@ namespace ContactDetailsApi.V2.UseCase.Interfaces
 {
     public interface IFetchAllContactDetailsByUprnUseCase
     {
-        Task<PagedResult<ContactByUprn>> ExecuteAsync(ServicesoftFetchContactDetailsRequest request);
+        Task<PagedResult<ContactByPropRef>> ExecuteAsync(ServicesoftFetchContactDetailsRequest request);
     }
 }


### PR DESCRIPTION
Due to requirements change from Service soft, the servicesoft endpoint has been updated to filter by property reference instead of uprn. 