### PR TITLE
Remove limit for servicesoft get all contact details

### DIFF
--- a/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByPropRefStep.cs
+++ b/ContactDetailsApi.Tests/V2/E2ETests/Steps/FetchAllContactDetailsByPropRefStep.cs
@@ -18,9 +18,9 @@ using System.Linq;
 
 namespace ContactDetailsApi.Tests.V2.E2ETests.Steps
 {
-    public class FetchAllContactDetailsByUprnStep : BaseSteps
+    public class FetchAllContactDetailsByPropRefStep : BaseSteps
     {
-        public FetchAllContactDetailsByUprnStep(HttpClient httpClient) : base(httpClient)
+        public FetchAllContactDetailsByPropRefStep(HttpClient httpClient) : base(httpClient)
         { }
 
         private async Task<HttpResponseMessage> CallApi()

--- a/ContactDetailsApi.Tests/V2/E2ETests/Stories/FetchAllContactDetailsTests.cs
+++ b/ContactDetailsApi.Tests/V2/E2ETests/Stories/FetchAllContactDetailsTests.cs
@@ -15,14 +15,14 @@ namespace ContactDetailsApi.Tests.V2.E2ETests.Stories
     {
         protected readonly IDynamoDbFixture _dbFixture;
         protected readonly ContactDetailsFixture _contactDetailsFixture;
-        protected readonly FetchAllContactDetailsByUprnStep _steps;
+        protected readonly FetchAllContactDetailsByPropRefStep _steps;
 
 
         public FetchAllContactDetailsTests(MockWebApplicationFactory<Startup> appFactory)
         {
             _dbFixture = appFactory.DynamoDbFixture;
             _contactDetailsFixture = new ContactDetailsFixture(_dbFixture.DynamoDbContext);
-            _steps = new FetchAllContactDetailsByUprnStep(appFactory.Client);
+            _steps = new FetchAllContactDetailsByPropRefStep(appFactory.Client);
 
         }
 

--- a/ContactDetailsApi.Tests/V2/UseCase/FetchAllContactDetailsUseCaseTests.cs
+++ b/ContactDetailsApi.Tests/V2/UseCase/FetchAllContactDetailsUseCaseTests.cs
@@ -22,7 +22,7 @@ namespace ContactDetailsApi.Tests.V2.UseCase
     [Collection("LogCall collection")]
     public class FetchAllContactDetailsUseCaseTests
     {
-        private readonly FetchAllContactDetailsByUprnUseCase _classUnderTest;
+        private readonly FetchAllContactDetailsByPropRefUseCase _classUnderTest;
         private readonly Mock<ITenureDbGateway> _mockTenureGateway;
         private readonly Mock<IPersonDbGateway> _mockPersonGateway;
         private readonly Mock<IContactDetailsGateway> _mockContactDetailsGateway;
@@ -35,7 +35,7 @@ namespace ContactDetailsApi.Tests.V2.UseCase
             _mockPersonGateway = new Mock<IPersonDbGateway>();
             _mockContactDetailsGateway = new Mock<IContactDetailsGateway>();
 
-            _classUnderTest = new FetchAllContactDetailsByUprnUseCase(_mockTenureGateway.Object,
+            _classUnderTest = new FetchAllContactDetailsByPropRefUseCase(_mockTenureGateway.Object,
                 _mockPersonGateway.Object, _mockContactDetailsGateway.Object);
 
         }

--- a/ContactDetailsApi/Startup.cs
+++ b/ContactDetailsApi/Startup.cs
@@ -183,7 +183,7 @@ namespace ContactDetailsApi
             services.AddScoped<V2.UseCase.Interfaces.IGetContactDetailsByTargetIdUseCase, V2.UseCase.GetContactDetailsByTargetIdUseCase>();
 
             services.AddScoped<IEditContactDetailsUseCase, V2.UseCase.EditContactDetailsUseCase>();
-            services.AddScoped<IFetchAllContactDetailsByUprnUseCase, FetchAllContactDetailsByUprnUseCase>();
+            services.AddScoped<IFetchAllContactDetailsByUprnUseCase, FetchAllContactDetailsByPropRefUseCase>();
 
         }
 

--- a/ContactDetailsApi/V2/Boundary/Request/ServicesoftFetchContactDetailsRequest.cs
+++ b/ContactDetailsApi/V2/Boundary/Request/ServicesoftFetchContactDetailsRequest.cs
@@ -9,7 +9,8 @@ namespace ContactDetailsApi.V2.Boundary.Request
         [FromQuery]
         public string PaginationToken { get; set; }
 
-        [FromQuery] [Range(1, int.MaxValue)]
+        [FromQuery]
+        [Range(1, int.MaxValue)]
         public int PageSize { get; set; } = int.MaxValue;
     }
 }

--- a/ContactDetailsApi/V2/Boundary/Request/ServicesoftFetchContactDetailsRequest.cs
+++ b/ContactDetailsApi/V2/Boundary/Request/ServicesoftFetchContactDetailsRequest.cs
@@ -9,8 +9,7 @@ namespace ContactDetailsApi.V2.Boundary.Request
         [FromQuery]
         public string PaginationToken { get; set; }
 
-        [FromQuery]
-        [Range(typeof(int), "1", "500")]
-        public int PageSize { get; set; } = 500;
+        [FromQuery] [Range(1, int.MaxValue)]
+        public int PageSize { get; set; } = int.MaxValue;
     }
 }

--- a/ContactDetailsApi/V2/Controllers/ServicesoftController.cs
+++ b/ContactDetailsApi/V2/Controllers/ServicesoftController.cs
@@ -29,8 +29,6 @@ namespace ContactDetailsApi.V2.Controllers
         [AuthorizeEndpointByIpWhitelist("WHITELIST_IP_ADDRESS")]
         public async Task<IActionResult> FetchAllContactDetailsByUprn([FromQuery] ServicesoftFetchContactDetailsRequest request)
         {
-            // Limit the page size to avoid API Gateway timeout (30s)
-            request.PageSize = Math.Clamp(request.PageSize, 1, 500);
             var results = await _fetchAllContactDetailsByUprnUseCase.ExecuteAsync(request);
 
             return Ok(results);

--- a/ContactDetailsApi/V2/UseCase/FetchAllContactDetailsByPropRefUseCase.cs
+++ b/ContactDetailsApi/V2/UseCase/FetchAllContactDetailsByPropRefUseCase.cs
@@ -14,14 +14,14 @@ using Hackney.Core.DynamoDb;
 
 namespace ContactDetailsApi.V2.UseCase
 {
-    public class FetchAllContactDetailsByUprnUseCase : IFetchAllContactDetailsByUprnUseCase
+    public class FetchAllContactDetailsByPropRefUseCase : IFetchAllContactDetailsByUprnUseCase
     {
 
         private readonly ITenureDbGateway _tenureGateway;
         private readonly IPersonDbGateway _personGateway;
         private readonly IContactDetailsGateway _contactGateway;
 
-        public FetchAllContactDetailsByUprnUseCase(ITenureDbGateway tenureGateway, IPersonDbGateway personGateway, IContactDetailsGateway contactGateway)
+        public FetchAllContactDetailsByPropRefUseCase(ITenureDbGateway tenureGateway, IPersonDbGateway personGateway, IContactDetailsGateway contactGateway)
         {
             _tenureGateway = tenureGateway;
             _personGateway = personGateway;


### PR DESCRIPTION
- Remove limit for the servicesoft get all contact details
- Rename more "get all by UPRN" to "get all by Propref"

We do not expect this to result in any timeout, however we will verify on dev - currently it is averaging around 15 seconds per scan locally, with 30 seconds remaining the time limit

The only functional change is in the `ServicesoftFetchContactDetailsRequest` and `ServicesoftController`