### PR TITLE
Disable scan consistent read

### DIFF
--- a/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/TenureDbGateway.cs
@@ -29,7 +29,7 @@ public class TenureDbGateway : ITenureDbGateway
     {
         var scanConfig = new ScanOperationConfig
         {
-            ConsistentRead = true,
+            ConsistentRead = false,
             Limit = pageSize ?? Int32.MaxValue,
             PaginationToken = PaginationDetails.DecodeToken(paginationToken)
         };


### PR DESCRIPTION
This greatly reduces the scan duration and halves the scan reads by preventing DynamoDB from re-checking scan results.

We do not need the data to be up to date to the second it is returned as it is a daily process, so this is a good performance and cost improvement