### PR TITLE
Make batch size configurable via environment variable

### DIFF
--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -145,7 +145,7 @@ namespace ContactDetailsApi.V2.Gateways
         public async Task<Dictionary<Guid, IEnumerable<ContactDetails>>> BatchGetContactDetailsByTargetId(List<Guid> targetIds)
         {
             var tasks = new List<Task<Dictionary<Guid, IEnumerable<ContactDetails>>>>();
-            var batchSize = _batchSizeEnv != null? int.Parse(_batchSizeEnv) : 30; // default to 30 if not set
+            var batchSize = _batchSizeEnv != null ? int.Parse(_batchSizeEnv) : 30; // default to 30 if not set
 
             int numberOfBatches = (int) Math.Ceiling((double) targetIds.Count / batchSize);
             _logger.LogDebug($"Batching contact details for {targetIds.Count} persons in {numberOfBatches} batches of {batchSize} each.");

--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -30,7 +30,7 @@ namespace ContactDetailsApi.V2.Gateways
             _logger = logger;
             _updater = updater;
 
-            _batchSizeEnv = Environment.GetEnvironmentVariable("BATCH_GET_SIZE");
+            _batchSizeEnv = Environment.GetEnvironmentVariable("BATCH_GET_CDS_SIZE");
         }
 
         [LogCall]

--- a/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
+++ b/ContactDetailsApi/V2/Gateways/ContactDetailsDynamoDbGateway.cs
@@ -21,12 +21,16 @@ namespace ContactDetailsApi.V2.Gateways
         private readonly IDynamoDBContext _dynamoDbContext;
         private readonly ILogger<ContactDetailsDynamoDbGateway> _logger;
         private readonly IEntityUpdater _updater;
+        private string _batchSizeEnv;
+
 
         public ContactDetailsDynamoDbGateway(IDynamoDBContext dynamoDbContext, ILogger<ContactDetailsDynamoDbGateway> logger, IEntityUpdater updater)
         {
             _dynamoDbContext = dynamoDbContext;
             _logger = logger;
             _updater = updater;
+
+            _batchSizeEnv = Environment.GetEnvironmentVariable("BATCH_GET_SIZE");
         }
 
         [LogCall]
@@ -141,7 +145,7 @@ namespace ContactDetailsApi.V2.Gateways
         public async Task<Dictionary<Guid, IEnumerable<ContactDetails>>> BatchGetContactDetailsByTargetId(List<Guid> targetIds)
         {
             var tasks = new List<Task<Dictionary<Guid, IEnumerable<ContactDetails>>>>();
-            var batchSize = 100;
+            var batchSize = _batchSizeEnv != null? int.Parse(_batchSizeEnv) : 30; // default to 30 if not set
 
             int numberOfBatches = (int) Math.Ceiling((double) targetIds.Count / batchSize);
             _logger.LogDebug($"Batching contact details for {targetIds.Count} persons in {numberOfBatches} batches of {batchSize} each.");

--- a/ContactDetailsApi/serverless.yml
+++ b/ContactDetailsApi/serverless.yml
@@ -27,7 +27,7 @@ functions:
       CONTACT_DETAILS_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/contact_details/arn}
       AUTH_ALLOWED_GROUPS_EXTERNAL: ${ssm:/housing/${self:provider.stage}/auth-allowed-groups-service-soft}
       WHITELIST_IP_ADDRESS: ${ssm:/housing/${self:provider.stage}/whitelist-ip-address-service-soft}
-      BATCH_GET_SIZE: ${ssm:/housing/${self:provider.stage}/contact-details-api/batch-get-size}
+      BATCH_GET_CDS_SIZE: ${ssm:/housing/${self:provider.stage}/contact-details-api/batch-get-size}
     events:
       - http:
           path: /{proxy+}

--- a/ContactDetailsApi/serverless.yml
+++ b/ContactDetailsApi/serverless.yml
@@ -27,6 +27,7 @@ functions:
       CONTACT_DETAILS_SNS_ARN: ${ssm:/sns-topic/${self:provider.stage}/contact_details/arn}
       AUTH_ALLOWED_GROUPS_EXTERNAL: ${ssm:/housing/${self:provider.stage}/auth-allowed-groups-service-soft}
       WHITELIST_IP_ADDRESS: ${ssm:/housing/${self:provider.stage}/whitelist-ip-address-service-soft}
+      BATCH_GET_SIZE: ${ssm:/housing/${self:provider.stage}/contact-details-api/batch-get-size}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
## Describe this PR

The current batch size of 100 is too large and may be causing our endpoint to slow down. The Lambda function appears to use only about a quarter of its allocated memory with a batch size of 100, so a default batch size of 30 should provide maximum efficiency. I've set it as an environment variable so that it can be adjusted if necessary.
