### PR TITLE
Return 200 and empty list when no contact details found for target ID

### DIFF
--- a/ContactDetailsApi/V2/Controllers/ContactDetailsController.cs
+++ b/ContactDetailsApi/V2/Controllers/ContactDetailsController.cs
@@ -28,19 +28,23 @@ namespace ContactDetailsApi.V2.Controllers
         private readonly IEditContactDetailsUseCase _editContactDetailsUseCase;
         private readonly IHttpContextWrapper _httpContextWrapper;
         private readonly ITokenFactory _tokenFactory;
+        private readonly ILogger<ContactDetailsController> _logger;
 
         public ContactDetailsController(
             ICreateContactUseCase createContactUseCase,
             IGetContactDetailsByTargetIdUseCase getContactDetailsByTargetIdUseCase,
             IHttpContextWrapper httpContextWrapper,
             ITokenFactory tokenFactory,
-            IEditContactDetailsUseCase editContactDetailsUseCase)
+            IEditContactDetailsUseCase editContactDetailsUseCase,
+            ILogger<ContactDetailsController> logger
+            )
         {
             _createContactUseCase = createContactUseCase;
             _getContactDetailsByTargetIdUseCase = getContactDetailsByTargetIdUseCase;
             _httpContextWrapper = httpContextWrapper;
             _tokenFactory = tokenFactory;
             _editContactDetailsUseCase = editContactDetailsUseCase;
+            _logger = logger;
         }
 
         /// <summary>
@@ -56,9 +60,9 @@ namespace ContactDetailsApi.V2.Controllers
         [LogCall(LogLevel.Information)]
         public async Task<IActionResult> GetContactDetailsByTargetId([FromQuery] ContactQueryParameter queryParam)
         {
+            _logger.LogInformation("GetContactDetailsByTargetId called for target id {0}", queryParam.TargetId);
             var contacts = await _getContactDetailsByTargetIdUseCase.Execute(queryParam).ConfigureAwait(false);
-            if (contacts == null || !contacts.Any()) return NotFound(queryParam.TargetId);
-
+            _logger.LogInformation("Returning {0} contact details for target id {1}", contacts.Count(), queryParam.TargetId);
             return Ok(new GetContactDetailsResponse(contacts));
         }
 

--- a/ContactDetailsApi/V2/UseCase/GetContactDetailsByTargetIdUseCase.cs
+++ b/ContactDetailsApi/V2/UseCase/GetContactDetailsByTargetIdUseCase.cs
@@ -4,9 +4,7 @@ using ContactDetailsApi.V2.Factories;
 using ContactDetailsApi.V2.Gateways.Interfaces;
 using ContactDetailsApi.V2.UseCase.Interfaces;
 using Hackney.Core.Logging;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace ContactDetailsApi.V2.UseCase


### PR DESCRIPTION
In HTTP, 404 is intended to be a "resource not found" response which suggests that the client made an improper request. This is suitable when getting specific items by ID.

Contact Details API returns 404 when there are no contact details associated with a target ID, which is improper. It's perfectly valid for a particular target ID to have no contact details against it - in this case probably a person record with no contact details (i.e. an empty list) attached to it.

This should be a 200 response with an empty list instead.
