### PR TITLE
Bump JWT code to 1.87.0 for Cognito Token support.

### DIFF
--- a/ContactDetailsApi/ContactDetailsApi.csproj
+++ b/ContactDetailsApi/ContactDetailsApi.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.83.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.72.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.72 -> 1.84 -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence. The only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.